### PR TITLE
Add manifest

### DIFF
--- a/champ/config.py
+++ b/champ/config.py
@@ -40,7 +40,8 @@ class CommandLineArguments(object):
         for possible_command in ('map',
                                  'init',
                                  'align',
-                                 'info'):
+                                 'info',
+                                 'notebooks'):
             if self._arguments.get(possible_command):
                 return possible_command
 

--- a/champ/controller/notebooks.py
+++ b/champ/controller/notebooks.py
@@ -8,13 +8,14 @@ log = logging.getLogger(__name__)
 
 def main(clargs):
     current_directory = os.getcwd()
-
     base = os.path.join(os.path.abspath(os.path.join(os.path.dirname(champ.__file__), '..')), 'notebooks')
     notebooks = os.listdir(base)
+
     for notebook in notebooks:
         notebook_path = os.path.join(base, notebook)
         destination = os.path.join(current_directory, notebook)
-        if os.path.isfile(destination):
-            log.warn("{notebook} already exists! SKIPPING!".format(notebook=notebook))
+        if os.path.exists(destination):
+            print("{notebook} already exists! SKIPPING!".format(notebook=notebook))
             continue
         shutil.copy(notebook_path, destination)
+        print("Created {notebook}".format(notebook=notebook))

--- a/champ/controller/notebooks.py
+++ b/champ/controller/notebooks.py
@@ -1,9 +1,6 @@
 import os
 import champ
-import logging
 import shutil
-
-log = logging.getLogger(__name__)
 
 
 def main(clargs):

--- a/champ/controller/notebooks.py
+++ b/champ/controller/notebooks.py
@@ -1,0 +1,20 @@
+import os
+import champ
+import logging
+import shutil
+
+log = logging.getLogger(__name__)
+
+
+def main(clargs):
+    current_directory = os.getcwd()
+
+    base = os.path.join(os.path.abspath(os.path.join(os.path.dirname(champ.__file__), '..')), 'notebooks')
+    notebooks = os.listdir(base)
+    for notebook in notebooks:
+        notebook_path = os.path.join(base, notebook)
+        destination = os.path.join(current_directory, notebook)
+        if os.path.isfile(destination):
+            log.warn("{notebook} already exists! SKIPPING!".format(notebook=notebook))
+            continue
+        shutil.copy(notebook_path, destination)

--- a/champ/main.py
+++ b/champ/main.py
@@ -6,6 +6,7 @@ Usage:
   champ init IMAGE_DIRECTORY READ_NAMES_DIRECTORY ALIGNMENT_CHANNEL [--perfect-target-name=PERFECT_TARGET_NAME] [--alternate-perfect-reads=ALTERNATE_PERFECT_READS] [--alternate-good-reads=ALTERNATE_GOOD_READS] [--alternate-fiducial-reads=ALTERNATE_FIDUCIAL_READS] [--microns-per-pixel=0.266666666] [--chip=miseq] [--ports-on-right] [--flipud] [--fliplr] [-v | -vv | -vvv ]
   champ align IMAGE_DIRECTORY [--rotation-adjustment=ROTATION_ADJUSTMENT] [--min-hits=MIN_HITS] [--snr=SNR] [--make-pdfs] [--fiducial-only] [-v | -vv | -vvv]
   champ info IMAGE_DIRECTORY
+  champ notebooks
 
 Options:
   -h --help     Show this screen.
@@ -16,13 +17,14 @@ Commands:
   init          Stores some metadata about a particular experiment
   align         Determines the sequence of fluorescent points in the microscope data. Preprocesses images if not already done.
   info          View the metadata associated with an experiment
+  notebooks     Creates copies of the standard Jupyter analysis notebooks in the current directory
 
 """
 import logging
 import os
 from champ.config import CommandLineArguments
 from champ.constants import VERSION
-from champ.controller import align, initialize, mapreads, info
+from champ.controller import align, initialize, mapreads, info, notebooks
 from docopt import docopt
 
 
@@ -41,7 +43,8 @@ def main(**kwargs):
     commands = {'align': align,
                 'init': initialize,
                 'map': mapreads,
-                'info': info}
+                'info': info,
+                'notebooks': notebooks}
 
     commands[arguments.command].main(arguments)
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,13 @@ if __name__ == '__main__':
               'champ = champ.main:main'
           ]
         },
+        include_package_data=True,
+        zip_safe=False,
+        data_files=[('notebooks', ['notebooks/all-lda-kd-fitting.ipynb',
+                                   'notebooks/data-analysis.ipynb',
+                                   'notebooks/genomic-kd-fitting.ipynb',
+                                   'notebooks/lda-intensity-estimation.ipynb',
+                                   'notebooks/thermodynamics.ipynb'])],
         description='Processes CHAMP image data',
         url='http://www.finkelsteinlab.org',
         keywords=['DNA', 'protein', 'illumina', 'bioinformatics', 'crispr'],


### PR DESCRIPTION
Resolves #60 - we can now automatically generate copies of all standard Jupyter notebooks into the current directory from source-controlled versions with the command "champ notebooks". Existing notebooks will not be clobbered