### PR TITLE
22 detect channels

### DIFF
--- a/champ/controller/initialize.py
+++ b/champ/controller/initialize.py
@@ -1,5 +1,5 @@
 import logging
-from champ import initialize
+from champ import initialize, error
 
 
 log = logging.getLogger(__name__)
@@ -10,6 +10,10 @@ def main(clargs):
         reduces the number of arguments that have to be specified in further commands, and also acts as a way of
         documenting the experiment. """
     channels = initialize.determine_channel_names(clargs.image_directory)
+    alignment_channel = clargs.alignment_channel
     if len(channels) > 1 and not clargs.alignment_channel:
         alignment_channel = initialize.request_alignment_channel(channels)
-    initialize.save_metadata(clargs)
+    elif clargs.alignment_channel and clargs.alignment_channel not in channels:
+        error.fail("The given alignment channel ('%s') does not exist in the image data. Available channels: %s" % (clargs.alignment_channel, ", ".join(channels)))
+    log.debug("Initializing with alignment channel: %s" % alignment_channel)
+    initialize.save_metadata(clargs, alignment_channel)

--- a/champ/controller/initialize.py
+++ b/champ/controller/initialize.py
@@ -10,10 +10,10 @@ def main(clargs):
         reduces the number of arguments that have to be specified in further commands, and also acts as a way of
         documenting the experiment. """
     channels = initialize.determine_channel_names(clargs.image_directory)
-    alignment_channel = clargs.alignment_channel
+    alignment_channel = channels[0] if len(channels) == 1 else clargs.alignment_channel
     if len(channels) > 1 and not clargs.alignment_channel:
         alignment_channel = initialize.request_alignment_channel(channels)
-    elif clargs.alignment_channel and clargs.alignment_channel not in channels:
+    if clargs.alignment_channel and clargs.alignment_channel not in channels:
         error.fail("The given alignment channel ('%s') does not exist in the image data. Available channels: %s" % (clargs.alignment_channel, ", ".join(channels)))
     log.debug("Initializing with alignment channel: %s" % alignment_channel)
     initialize.save_metadata(clargs, alignment_channel)

--- a/champ/controller/initialize.py
+++ b/champ/controller/initialize.py
@@ -9,4 +9,7 @@ def main(clargs):
     """ Stores details of the experiment that are needed for all analyses. This accomplishes two things: first, it
         reduces the number of arguments that have to be specified in further commands, and also acts as a way of
         documenting the experiment. """
+    channels = initialize.determine_channel_names(clargs.image_directory)
+    if len(channels) > 1 and not clargs.alignment_channel:
+        alignment_channel = initialize.request_alignment_channel(channels)
     initialize.save_metadata(clargs)

--- a/champ/convert.py
+++ b/champ/convert.py
@@ -11,10 +11,8 @@ log = logging.getLogger(__name__)
 
 
 def load_channel_names(tifs):
-    log.debug("load_channel_names")
     channels = set()
     for filename in tifs:
-        log.debug("load channel names for %s" % filename)
         tif = tifffile.TiffFile(filename)
         for channel in tif.micromanager_metadata['summary']['ChNames']:
             channels.add(sanitize_name(channel))

--- a/champ/convert.py
+++ b/champ/convert.py
@@ -11,8 +11,10 @@ log = logging.getLogger(__name__)
 
 
 def load_channel_names(tifs):
+    log.debug("load_channel_names")
     channels = set()
     for filename in tifs:
+        log.debug("load channel names for %s" % filename)
         tif = tifffile.TiffFile(filename)
         for channel in tif.micromanager_metadata['summary']['ChNames']:
             channels.add(sanitize_name(channel))

--- a/champ/convert.py
+++ b/champ/convert.py
@@ -1,13 +1,22 @@
 import tifffile
 import os
 import numpy as np
-from champ.tiff import TifsPerConcentration, TifsPerFieldOfView
+from champ.tiff import TifsPerConcentration, TifsPerFieldOfView, sanitize_name
 from collections import defaultdict
 import h5py
 import logging
 
 
 log = logging.getLogger(__name__)
+
+
+def load_channel_names(tifs):
+    channels = set()
+    for filename in tifs:
+        tif = tifffile.TiffFile(filename)
+        for channel in tif.micromanager_metadata['summary']['ChNames']:
+            channels.add(sanitize_name(channel))
+    return tuple(channels)
 
 
 def load_tiff_stack(tifs, adjustments):

--- a/champ/initialize.py
+++ b/champ/initialize.py
@@ -1,7 +1,7 @@
 import os
 import yaml
 from champ.error import fail
-from champ.convert import load_tiff_stack, get_all_tif_paths
+from champ.convert import get_all_tif_paths, load_channel_names
 
 
 def save_metadata(clargs, alignment_channel):
@@ -63,10 +63,8 @@ def determine_channel_names(image_directory):
     channels = set()
     paths = get_all_tif_paths(image_directory)
     for directory, tifs in paths.items():
-        stack = load_tiff_stack(list(tifs), ())
-        for fov in stack:
-            for channel in fov.channels:
-                channels.add(channel)
+        for channel in load_channel_names(tifs):
+            channels.add(channel)
     return tuple(channels)
 
 

--- a/champ/initialize.py
+++ b/champ/initialize.py
@@ -11,7 +11,7 @@ def save_metadata(clargs, alignment_channel):
                 'microns_per_pixel': clargs.microns_per_pixel,
                 'chip_type': str(clargs.chip),
                 'ports_on_right': clargs.ports_on_right,
-                'alignment_channel': alignment_channel,
+                'alignment_channel': str(alignment_channel),
                 'alternate_fiducial_reads': clargs.alternate_fiducial_reads,
                 'alternate_perfect_target_reads_filename': clargs.alternate_perfect_target_reads_filename,
                 'alternate_good_target_reads_filename': clargs.alternate_good_target_reads_filename,

--- a/champ/initialize.py
+++ b/champ/initialize.py
@@ -63,13 +63,17 @@ def get_existing_metadata_filename(image_directory):
 
 
 def determine_channel_names(image_directory):
-    log.debug('Determine channel names for %s' % image_directory)
+    """
+    Looks at a single concentration/timepoint at random and gets all the channel names
+    
+    """
+    log.debug("Checking channel names.")
     channels = set()
     paths = get_all_tif_paths(image_directory)
-    log.debug("len(paths): %d" % len(paths))
     for directory, tifs in paths.items():
         for channel in load_channel_names(tifs):
             channels.add(channel)
+        break
     return tuple(channels)
 
 

--- a/champ/initialize.py
+++ b/champ/initialize.py
@@ -63,7 +63,7 @@ def determine_channel_names(image_directory):
     channels = set()
     paths = get_all_tif_paths(image_directory)
     for directory, tifs in paths.items():
-        stack = load_tiff_stack(tifs, ())
+        stack = load_tiff_stack(list(tifs), ())
         for fov in stack:
             for channel in fov.channels:
                 channels.add(channel)

--- a/champ/initialize.py
+++ b/champ/initialize.py
@@ -4,14 +4,14 @@ from champ.error import fail
 from champ.convert import load_tiff_stack, get_all_tif_paths
 
 
-def save_metadata(clargs):
+def save_metadata(clargs, alignment_channel):
     filename = os.path.join(clargs.image_directory, 'champ.yml')
     with open(filename, 'w') as f:
         data = {'mapped_reads': os.path.abspath(clargs.mapped_reads),
                 'microns_per_pixel': clargs.microns_per_pixel,
                 'chip_type': str(clargs.chip),
                 'ports_on_right': clargs.ports_on_right,
-                'alignment_channel': clargs.alignment_channel,
+                'alignment_channel': alignment_channel,
                 'alternate_fiducial_reads': clargs.alternate_fiducial_reads,
                 'alternate_perfect_target_reads_filename': clargs.alternate_perfect_target_reads_filename,
                 'alternate_good_target_reads_filename': clargs.alternate_good_target_reads_filename,

--- a/champ/initialize.py
+++ b/champ/initialize.py
@@ -2,6 +2,9 @@ import os
 import yaml
 from champ.error import fail
 from champ.convert import get_all_tif_paths, load_channel_names
+import logging
+
+log = logging.getLogger(__name__)
 
 
 def save_metadata(clargs, alignment_channel):
@@ -60,8 +63,10 @@ def get_existing_metadata_filename(image_directory):
 
 
 def determine_channel_names(image_directory):
+    log.debug('Determine channel names for %s' % image_directory)
     channels = set()
     paths = get_all_tif_paths(image_directory)
+    log.debug("len(paths): %d" % len(paths))
     for directory, tifs in paths.items():
         for channel in load_channel_names(tifs):
             channels.add(channel)

--- a/champ/main.py
+++ b/champ/main.py
@@ -3,7 +3,7 @@ Chip-Hybridized Affinity Mapping Platform
 
 Usage:
   champ map FASTQ_DIRECTORY OUTPUT_DIRECTORY [--log-p-file=LOG_P_FILE] [--target-sequence-file=TARGET_SEQUENCE_FILE] [--phix-bowtie=PHIX_BOWTIE] [--min-len=MIN_LEN] [--max-len=MAX_LEN] [-v | -vv | -vvv]
-  champ init IMAGE_DIRECTORY READ_NAMES_DIRECTORY ALIGNMENT_CHANNEL [--perfect-target-name=PERFECT_TARGET_NAME] [--alternate-perfect-reads=ALTERNATE_PERFECT_READS] [--alternate-good-reads=ALTERNATE_GOOD_READS] [--alternate-fiducial-reads=ALTERNATE_FIDUCIAL_READS] [--microns-per-pixel=0.266666666] [--chip=miseq] [--ports-on-right] [--flipud] [--fliplr] [-v | -vv | -vvv ]
+  champ init IMAGE_DIRECTORY READ_NAMES_DIRECTORY [ALIGNMENT_CHANNEL] [--perfect-target-name=PERFECT_TARGET_NAME] [--alternate-perfect-reads=ALTERNATE_PERFECT_READS] [--alternate-good-reads=ALTERNATE_GOOD_READS] [--alternate-fiducial-reads=ALTERNATE_FIDUCIAL_READS] [--microns-per-pixel=0.266666666] [--chip=miseq] [--ports-on-right] [--flipud] [--fliplr] [-v | -vv | -vvv ]
   champ align IMAGE_DIRECTORY [--rotation-adjustment=ROTATION_ADJUSTMENT] [--min-hits=MIN_HITS] [--snr=SNR] [--make-pdfs] [--fiducial-only] [-v | -vv | -vvv]
   champ info IMAGE_DIRECTORY
   champ notebooks

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -170,3 +170,7 @@ class TIFSingleFieldOfView(object):
     def __iter__(self):
         for channel, image in self._summed_images.items():
             yield channel, image
+
+    @property
+    def channels(self):
+        return self._summed_images.keys()


### PR DESCRIPTION
Resolves #22 - providing the alignment channel is now optional. If there's only a single channel, CHAMP will detect that automatically during the `init` step and save it in the config file. If there are multiple channels, CHAMP will prompt the user to pick one. 

If the user does provide the alignment channel, CHAMP will still check to make sure that channel is present in the data, and print an error message with the available channels if it's not valid.