### PR TITLE
Optionally ignore  side 1 read names

### DIFF
--- a/champ/config.py
+++ b/champ/config.py
@@ -68,6 +68,10 @@ class CommandLineArguments(object):
         return self._arguments['IMAGE_DIRECTORY']
 
     @property
+    def include_side_1(self):
+        return self._arguments['--include-side-1']
+
+    @property
     def log_level(self):
         log_level = {0: logging.ERROR,
                      1: logging.WARN,

--- a/champ/main.py
+++ b/champ/main.py
@@ -2,7 +2,7 @@
 Chip-Hybridized Affinity Mapping Platform
 
 Usage:
-  champ map FASTQ_DIRECTORY OUTPUT_DIRECTORY [--log-p-file=LOG_P_FILE] [--target-sequence-file=TARGET_SEQUENCE_FILE] [--phix-bowtie=PHIX_BOWTIE] [--min-len=MIN_LEN] [--max-len=MAX_LEN] [-v | -vv | -vvv]
+  champ map FASTQ_DIRECTORY OUTPUT_DIRECTORY [--log-p-file=LOG_P_FILE] [--target-sequence-file=TARGET_SEQUENCE_FILE] [--phix-bowtie=PHIX_BOWTIE] [--min-len=MIN_LEN] [--max-len=MAX_LEN] [--include-side-1] [-v | -vv | -vvv]
   champ init IMAGE_DIRECTORY READ_NAMES_DIRECTORY [ALIGNMENT_CHANNEL] [--perfect-target-name=PERFECT_TARGET_NAME] [--alternate-perfect-reads=ALTERNATE_PERFECT_READS] [--alternate-good-reads=ALTERNATE_GOOD_READS] [--alternate-fiducial-reads=ALTERNATE_FIDUCIAL_READS] [--microns-per-pixel=0.266666666] [--chip=miseq] [--ports-on-right] [--flipud] [--fliplr] [-v | -vv | -vvv ]
   champ align IMAGE_DIRECTORY [--rotation-adjustment=ROTATION_ADJUSTMENT] [--min-hits=MIN_HITS] [--snr=SNR] [--make-pdfs] [--fiducial-only] [-v | -vv | -vvv]
   champ info IMAGE_DIRECTORY

--- a/champ/readmap.py
+++ b/champ/readmap.py
@@ -27,7 +27,10 @@ def main(clargs):
     fastq_filenames = [os.path.join(clargs.fastq_directory, directory) for directory in os.listdir(clargs.fastq_directory)]
     fastq_files = FastqFiles(fastq_filenames)
     read_names_given_seq = {}
-    usable_read = lambda record_id: True if clargs.include_side_1 else lambda record_id: determine_side(record_id) == '2'
+    if clargs.include_side_1:
+        usable_read = lambda record_id: True
+    else:
+        usable_read = lambda record_id: determine_side(record_id) == '2'
 
     if clargs.log_p_file_path:
         # We need to find the sequence of each read name
@@ -36,6 +39,7 @@ def main(clargs):
             log_p_struct = pickle.load(f)
 
         read_names_given_seq = determine_sequences_of_read_names(clargs.min_len, clargs.max_len, log_p_struct, fastq_files, usable_read)
+        print("read names given seq: %d" % len(read_names_given_seq))
         write_read_names_by_sequence(read_names_given_seq, os.path.join(clargs.output_directory, 'read_names_by_seq.txt'))
 
     if not read_names_given_seq:

--- a/champ/readmap.py
+++ b/champ/readmap.py
@@ -39,7 +39,6 @@ def main(clargs):
             log_p_struct = pickle.load(f)
 
         read_names_given_seq = determine_sequences_of_read_names(clargs.min_len, clargs.max_len, log_p_struct, fastq_files, usable_read)
-        print("read names given seq: %d" % len(read_names_given_seq))
         write_read_names_by_sequence(read_names_given_seq, os.path.join(clargs.output_directory, 'read_names_by_seq.txt'))
 
     if not read_names_given_seq:

--- a/champ/seqtools.py
+++ b/champ/seqtools.py
@@ -198,6 +198,22 @@ def build_read_names_given_seq(target,
     return interesting_reads
 
 
+def build_interesting_sequences(read_names_by_seq_filepath, interesting_sequences):
+    interesting_read_names = {}
+    with open(read_names_by_seq_filepath) as f:
+        for i, line in enumerate(f):
+            if i % 10000 == 0:
+                sys.stdout.write('.')
+                sys.stdout.flush()
+            words = line.strip().split()
+            rough_sequence = words[0]
+            read_names = words[1:]
+            for interesting_sequence in interesting_sequences:
+                if interesting_sequence in rough_sequence:
+                    interesting_read_names[interesting_sequence] = read_names
+    return interesting_read_names
+
+
 def plot_library_comp_by_hamming_distance(ax,
                                           target,
                                           max_ham,


### PR DESCRIPTION
We're unable to visualize DNA on side 1 of the chip, so there's no point in processing those reads at any point. This won't change any outputs since we eventually filter them anyway, but removing them at the  beginning it will save time during downstream processing steps. Now, by default, only side 2 reads will be saved, but a command line option can override this in case some breakthrough allows us to visualize both sides.