### PR TITLE
The default minimum number of exclusive/good-mutual hits is only 15 -…

### DIFF
--- a/champ/config.py
+++ b/champ/config.py
@@ -103,7 +103,7 @@ class CommandLineArguments(object):
 
     @property
     def min_hits(self):
-        return int(self._arguments['--min-hits'] or 15)
+        return int(self._arguments['--min-hits'] or 150)
 
     @property
     def min_len(self):


### PR DESCRIPTION
… this is unacceptably low in almost all cases.