### PR TITLE
93 split large images

### DIFF
--- a/champ/fastqimagealigner.py
+++ b/champ/fastqimagealigner.py
@@ -119,12 +119,14 @@ class FastqImageAligner(object):
 
         for control_tile in control_tiles:
             corr, _ = control_tile.fft_align_with_im(self.image_data)
+            log.debug("Control corr: %s" % corr)
             if corr > self.control_corr:
                 self.control_corr = corr
         del control_tiles
         self.hitting_tiles = []
         for tile in possible_tiles:
             max_corr, align_tr = tile.fft_align_with_im(self.image_data)
+            log.debug("Max corr: %s" % max_corr)
             if max_corr > snr_thresh * self.control_corr:
                 tile.set_aligned_rcs(align_tr)
                 tile.snr = max_corr / self.control_corr

--- a/champ/imagedata.py
+++ b/champ/imagedata.py
@@ -24,6 +24,8 @@ class ImageData(object):
         w = misc.next_power_of_2(totalx)
         h = misc.next_power_of_2(totaly)
         padded_im = np.pad(self.image,
-                           ((int(padding[0]), int(w-totalx)), (int(padding[1]), int(h-totaly))),
+                           ((int(padding[0]), int(w) - int(totalx)), (int(padding[1]), int(h) - int(totaly))),
                            mode='constant')
+        if padded_im.shape != (h, w):
+            raise ValueError("FFT of microscope image is not a power of 2, this will cause the program to stall.")
         self.fft = np.fft.fft2(padded_im)

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -134,7 +134,7 @@ class TifsPerConcentration(BaseTifStack):
 
                 # if the images are larger than 512x512, we need to subdivide them
                 subrows, subcolumns = range(height / 512), range(width / 512)
-
+                log.debug("subrows: %d, subcolumns: %d" % (subrows, subcolumns))
                 # Find channel names and assert unique
                 channel_names = [sanitize_name(name) for name in summary['ChNames']]
                 assert summary['Channels'] == len(channel_names) == len(set(channel_names)), channel_names
@@ -153,6 +153,7 @@ class TifsPerConcentration(BaseTifStack):
                         for subcolumn in subcolumns:
                             major_axis_label = (major_axis_position * len(subcolumns)) - len(subcolumns) + subcolumn
                             dataset_name = '(Major, minor) = ({}, {})'.format(major_axis_label, minor_axis_label)
+                            log.debug(dataset_name)
                             summed_images = defaultdict(lambda *x: np.zeros((height, width), dtype=np.int))
 
                             # Add images

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -134,7 +134,7 @@ class TifsPerConcentration(BaseTifStack):
 
                 # if the images are larger than 512x512, we need to subdivide them
                 subrows, subcolumns = range(height / 512), range(width / 512)
-                log.debug("subrows: %d, subcolumns: %d" % (subrows, subcolumns))
+                log.debug("subrows: %s, subcolumns: %s" % (subrows, subcolumns))
                 # Find channel names and assert unique
                 channel_names = [sanitize_name(name) for name in summary['ChNames']]
                 assert summary['Channels'] == len(channel_names) == len(set(channel_names)), channel_names

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -90,7 +90,7 @@ class TifsPerFieldOfView(BaseTifStack):
 
                             # Setup defaultdict
                             height, width = summary['Height'], summary['Width']
-                            summed_images = defaultdict(lambda *x: np.zeros((height, width), dtype=np.int))
+                            summed_images = defaultdict(lambda *x: np.zeros((512, 512), dtype=np.int))
 
                             # Add images
                             for channel, page in zip(channels, tif.pages):
@@ -167,7 +167,7 @@ class TifsPerConcentration(BaseTifStack):
                         for subcolumn in subcolumns:
                             major_axis_label = (major_axis_position * len(subcolumns)) - len(subcolumns) + subcolumn + 1
                             dataset_name = '(Major, minor) = ({}, {})'.format(major_axis_label, minor_axis_label)
-                            summed_images = defaultdict(lambda *x: np.zeros((height, width), dtype=np.int))
+                            summed_images = defaultdict(lambda *x: np.zeros((512, 512), dtype=np.int))
                             # Add images
                             for channel, page in channel_pages:
                                 image = page.asarray()

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -73,7 +73,7 @@ class TifsPerFieldOfView(BaseTifStack):
             for file_path in self._filenames:
                 major_axis_position, minor_axis_position = self.axes[file_path]
                 for subrow in subrows:
-                    minor_axis_label = (minor_axis_position * len(subrows)) - len(subrows) + subrow
+                    minor_axis_label = (minor_axis_position * len(subrows)) + subrow
                     for subcolumn in subcolumns:
                         major_axis_label = (major_axis_position * len(subcolumns)) - len(subcolumns) + subcolumn + 2
                         dataset_name = '(Major, minor) = ({}, {})'.format(major_axis_label, minor_axis_label)
@@ -163,7 +163,7 @@ class TifsPerConcentration(BaseTifStack):
                 for position_text, channel_pages in all_pages.items():
                     major_axis_position, minor_axis_position = self.axes[file_path][position_text]
                     for subrow in subrows:
-                        minor_axis_label = (minor_axis_position * len(subrows)) - len(subrows) + subrow + 1
+                        minor_axis_label = (minor_axis_position * len(subrows)) + subrow
                         for subcolumn in subcolumns:
                             major_axis_label = (major_axis_position * len(subcolumns)) - len(subcolumns) + subcolumn + 1
                             dataset_name = '(Major, minor) = ({}, {})'.format(major_axis_label, minor_axis_label)

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -73,9 +73,9 @@ class TifsPerFieldOfView(BaseTifStack):
             for file_path in self._filenames:
                 major_axis_position, minor_axis_position = self.axes[file_path]
                 for subrow in subrows:
-                    minor_axis_label = (minor_axis_position * len(subrows)) - len(subrows) + subrow + 1
+                    minor_axis_label = (minor_axis_position * len(subrows)) - len(subrows) + subrow
                     for subcolumn in subcolumns:
-                        major_axis_label = (major_axis_position * len(subcolumns)) - len(subcolumns) + subcolumn + 1
+                        major_axis_label = (major_axis_position * len(subcolumns)) - len(subcolumns) + subcolumn + 2
                         dataset_name = '(Major, minor) = ({}, {})'.format(major_axis_label, minor_axis_label)
 
                         with tifffile.TiffFile(file_path) as tif:

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -149,9 +149,9 @@ class TifsPerConcentration(BaseTifStack):
                 for position_text, channel_pages in all_pages.items():
                     major_axis_position, minor_axis_position = self.axes[file_path][position_text]
                     for subrow in subrows:
-                        minor_axis_label = (minor_axis_position * len(subrows)) - len(subrows) + subrow
+                        minor_axis_label = (minor_axis_position * len(subrows)) - len(subrows) + subrow + 1
                         for subcolumn in subcolumns:
-                            major_axis_label = (major_axis_position * len(subcolumns)) - len(subcolumns) + subcolumn
+                            major_axis_label = (major_axis_position * len(subcolumns)) - len(subcolumns) + subcolumn + 1
                             dataset_name = '(Major, minor) = ({}, {})'.format(major_axis_label, minor_axis_label)
                             log.debug(dataset_name)
                             summed_images = defaultdict(lambda *x: np.zeros((height, width), dtype=np.int))

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -61,31 +61,46 @@ class TifsPerFieldOfView(BaseTifStack):
         return self._axes
 
     def __iter__(self):
-        for file_path in self._filenames:
-            major_axis_position, minor_axis_position = self.axes[file_path]
-            dataset_name = '(Major, minor) = ({}, {})'.format(major_axis_position, minor_axis_position)
+        first_filename = self._filenames[0]
+        with tifffile.TiffFile(first_filename) as tif:
+            summary = tif.micromanager_metadata['summary']
+            height, width = summary['Height'], summary['Width']
+            if height % 512 != 0 or width % 512 != 0:
+                raise ValueError("CHAMP currently only supports images with sides that are multiples of 512 pixels.")
+            # if the images are larger than 512x512, we need to subdivide them
+            subrows, subcolumns = range(height / 512), range(width / 512)
 
-            with tifffile.TiffFile(file_path) as tif:
-                summary = tif.micromanager_metadata['summary']
+            for file_path in self._filenames:
+                major_axis_position, minor_axis_position = self.axes[file_path]
+                for subrow in subrows:
+                    minor_axis_label = (minor_axis_position * len(subrows)) - len(subrows) + subrow + 1
+                    for subcolumn in subcolumns:
+                        major_axis_label = (major_axis_position * len(subcolumns)) - len(subcolumns) + subcolumn + 1
+                        dataset_name = '(Major, minor) = ({}, {})'.format(major_axis_label, minor_axis_label)
 
-                # Find channel names and assert unique
-                channel_names = [sanitize_name(name) for name in summary['ChNames']]
-                assert summary['Channels'] == len(channel_names) == len(set(channel_names)), channel_names
+                        with tifffile.TiffFile(file_path) as tif:
+                            summary = tif.micromanager_metadata['summary']
 
-                # channel_idxs map tif pages to channels
-                channels = [channel_names[i] for i in tif.micromanager_metadata['index_map']['channel']]
+                            # Find channel names and assert unique
+                            channel_names = [sanitize_name(name) for name in summary['ChNames']]
+                            assert summary['Channels'] == len(channel_names) == len(set(channel_names)), channel_names
 
-                # Setup defaultdict
-                height, width = summary['Height'], summary['Width']
-                summed_images = defaultdict(lambda *x: np.zeros((height, width), dtype=np.int))
+                            # channel_idxs map tif pages to channels
+                            channels = [channel_names[i] for i in tif.micromanager_metadata['index_map']['channel']]
 
-                # Add images
-                for channel, page in zip(channels, tif.pages):
-                    image = page.asarray()
-                    for adjustment in self._adjustments:
-                        image = adjustment(image)
-                    summed_images[channel] += image
-                yield TIFSingleFieldOfView(summed_images, dataset_name)
+                            # Setup defaultdict
+                            height, width = summary['Height'], summary['Width']
+                            summed_images = defaultdict(lambda *x: np.zeros((height, width), dtype=np.int))
+
+                            # Add images
+                            for channel, page in zip(channels, tif.pages):
+                                image = page.asarray()
+                                # this subdivision might be incorrect formally, it might be putting them in the wrong part of the larger "box"
+                                image = image[subrow * 512: (subrow * 512) + 512, subcolumn * 512: (subcolumn * 512) + 512]
+                                for adjustment in self._adjustments:
+                                    image = adjustment(image)
+                                summed_images[channel] += image
+                            yield TIFSingleFieldOfView(summed_images, dataset_name)
 
 
 class TifsPerConcentration(BaseTifStack):
@@ -134,7 +149,6 @@ class TifsPerConcentration(BaseTifStack):
 
                 # if the images are larger than 512x512, we need to subdivide them
                 subrows, subcolumns = range(height / 512), range(width / 512)
-                log.debug("subrows: %s, subcolumns: %s" % (subrows, subcolumns))
                 # Find channel names and assert unique
                 channel_names = [sanitize_name(name) for name in summary['ChNames']]
                 assert summary['Channels'] == len(channel_names) == len(set(channel_names)), channel_names
@@ -153,12 +167,12 @@ class TifsPerConcentration(BaseTifStack):
                         for subcolumn in subcolumns:
                             major_axis_label = (major_axis_position * len(subcolumns)) - len(subcolumns) + subcolumn + 1
                             dataset_name = '(Major, minor) = ({}, {})'.format(major_axis_label, minor_axis_label)
-                            log.debug(dataset_name)
                             summed_images = defaultdict(lambda *x: np.zeros((height, width), dtype=np.int))
-
                             # Add images
                             for channel, page in channel_pages:
                                 image = page.asarray()
+                                # this subdivision might be incorrect formally, it might be putting them in the wrong part of the larger "box"
+                                image = image[subrow * 512: (subrow * 512) + 512, subcolumn * 512: (subcolumn * 512) + 512]
                                 for adjustment in self._adjustments:
                                     image = adjustment(image)
                                 summed_images[channel] += image


### PR DESCRIPTION
Resolves #93 - images larger than 512x512 are split into 512x512 chunks during the HDF5 creation step. Images need to be multiples of 512 on each side.