### PR TITLE
Process limit

### DIFF
--- a/champ/align.py
+++ b/champ/align.py
@@ -20,9 +20,11 @@ log = logging.getLogger(__name__)
 stats_regex = re.compile(r'''^(\w+)_(?P<row>\d+)_(?P<column>\d+)_stats\.txt$''')
 
 
-def run(cluster_strategy, rotation_adjustment, h5_filenames, path_info, snr, min_hits, fia, end_tiles, alignment_channel, all_tile_data, metadata, make_pdfs, sequencing_chip):
+def run(cluster_strategy, rotation_adjustment, h5_filenames, path_info, snr, min_hits, fia, end_tiles, alignment_channel, all_tile_data, metadata, make_pdfs, sequencing_chip, process_limit):
     image_count = count_images(h5_filenames, alignment_channel)
     num_processes, chunksize = calculate_process_count(image_count)
+    if process_limit > 0:
+        num_processes = min(process_limit, num_processes)
     log.debug("Aligning alignment images with %d cores with chunksize %d" % (num_processes, chunksize))
 
     # Iterate over images that are probably inside an Illumina tile, attempt to align them, and if they
@@ -39,9 +41,11 @@ def run(cluster_strategy, rotation_adjustment, h5_filenames, path_info, snr, min
     log.debug("Done aligning!")
 
 
-def run_data_channel(cluster_strategy, h5_filenames, channel_name, path_info, alignment_tile_data, all_tile_data, metadata, clargs):
+def run_data_channel(cluster_strategy, h5_filenames, channel_name, path_info, alignment_tile_data, all_tile_data, metadata, clargs, process_limit):
     image_count = count_images(h5_filenames, channel_name)
     num_processes, chunksize = calculate_process_count(image_count)
+    if process_limit > 0:
+        num_processes = min(process_limit, num_processes)
     log.debug("Aligning data images with %d cores with chunksize %d" % (num_processes, chunksize))
 
     log.debug("Loading reads into FASTQ Image Aligner.")

--- a/champ/config.py
+++ b/champ/config.py
@@ -127,6 +127,11 @@ class CommandLineArguments(object):
         return self._arguments['--ports-on-right']
 
     @property
+    def process_limit(self):
+        # 0 indicates unlimited
+        return int(self._arguments['--process-limit'] or 0)
+
+    @property
     def rotation_adjustment(self):
         return float(self._arguments['--rotation-adjustment'] or 0.0)
 

--- a/champ/controller/align.py
+++ b/champ/controller/align.py
@@ -69,7 +69,7 @@ def main(clargs):
     if not cache['phix_aligned']:
         for cluster_strategy in cluster_strategies:
             align.run(cluster_strategy, clargs.rotation_adjustment, h5_filenames, path_info, clargs.snr, clargs.min_hits, fia, end_tiles, metadata['alignment_channel'],
-                      all_tile_data, metadata, clargs.make_pdfs, sequencing_chip)
+                      all_tile_data, metadata, clargs.make_pdfs, sequencing_chip, clargs.process_limit)
             cache['phix_aligned'] = True
             initialize.save_cache(clargs.image_directory, cache)
         else:
@@ -107,6 +107,6 @@ def main(clargs):
 def combo_align(cluster_strategy, h5_filenames, channel_combo, channel_name, path_info, alignment_tile_data, all_tile_data, metadata, cache, clargs):
     log.info("Aligning %s" % channel_combo)
     if channel_combo not in cache['protein_channels_aligned']:
-        align.run_data_channel(cluster_strategy, h5_filenames, channel_name, path_info, alignment_tile_data, all_tile_data, metadata, clargs)
+        align.run_data_channel(cluster_strategy, h5_filenames, channel_name, path_info, alignment_tile_data, all_tile_data, metadata, clargs, clargs.process_limit)
         cache['protein_channels_aligned'].append(channel_combo)
         initialize.save_cache(clargs.image_directory, cache)

--- a/champ/main.py
+++ b/champ/main.py
@@ -5,7 +5,7 @@ Usage:
   champ map FASTQ_DIRECTORY OUTPUT_DIRECTORY [--log-p-file=LOG_P_FILE] [--target-sequence-file=TARGET_SEQUENCE_FILE] [--phix-bowtie=PHIX_BOWTIE] [--min-len=MIN_LEN] [--max-len=MAX_LEN] [--include-side-1] [-v | -vv | -vvv]
   champ init IMAGE_DIRECTORY READ_NAMES_DIRECTORY [ALIGNMENT_CHANNEL] [--perfect-target-name=PERFECT_TARGET_NAME] [--alternate-perfect-reads=ALTERNATE_PERFECT_READS] [--alternate-good-reads=ALTERNATE_GOOD_READS] [--alternate-fiducial-reads=ALTERNATE_FIDUCIAL_READS] [--microns-per-pixel=0.266666666] [--chip=miseq] [--ports-on-right] [--flipud] [--fliplr] [-v | -vv | -vvv ]
   champ h5 IMAGE_DIRECTORY [-v | -vv | -vvv]
-  champ align IMAGE_DIRECTORY [--rotation-adjustment=ROTATION_ADJUSTMENT] [--min-hits=MIN_HITS] [--snr=SNR] [--make-pdfs] [--fiducial-only] [--process-limit] [-v | -vv | -vvv]
+  champ align IMAGE_DIRECTORY [--rotation-adjustment=ROTATION_ADJUSTMENT] [--min-hits=MIN_HITS] [--snr=SNR] [--process-limit=PROCESS_LIMIT] [--make-pdfs] [--fiducial-only] [-v | -vv | -vvv]
   champ info IMAGE_DIRECTORY
   champ notebooks
 

--- a/champ/main.py
+++ b/champ/main.py
@@ -5,7 +5,7 @@ Usage:
   champ map FASTQ_DIRECTORY OUTPUT_DIRECTORY [--log-p-file=LOG_P_FILE] [--target-sequence-file=TARGET_SEQUENCE_FILE] [--phix-bowtie=PHIX_BOWTIE] [--min-len=MIN_LEN] [--max-len=MAX_LEN] [--include-side-1] [-v | -vv | -vvv]
   champ init IMAGE_DIRECTORY READ_NAMES_DIRECTORY [ALIGNMENT_CHANNEL] [--perfect-target-name=PERFECT_TARGET_NAME] [--alternate-perfect-reads=ALTERNATE_PERFECT_READS] [--alternate-good-reads=ALTERNATE_GOOD_READS] [--alternate-fiducial-reads=ALTERNATE_FIDUCIAL_READS] [--microns-per-pixel=0.266666666] [--chip=miseq] [--ports-on-right] [--flipud] [--fliplr] [-v | -vv | -vvv ]
   champ h5 IMAGE_DIRECTORY [-v | -vv | -vvv]
-  champ align IMAGE_DIRECTORY [--rotation-adjustment=ROTATION_ADJUSTMENT] [--min-hits=MIN_HITS] [--snr=SNR] [--make-pdfs] [--fiducial-only] [-v | -vv | -vvv]
+  champ align IMAGE_DIRECTORY [--rotation-adjustment=ROTATION_ADJUSTMENT] [--min-hits=MIN_HITS] [--snr=SNR] [--make-pdfs] [--fiducial-only] [--process-limit] [-v | -vv | -vvv]
   champ info IMAGE_DIRECTORY
   champ notebooks
 


### PR DESCRIPTION
Resolves #105: The user can manually specify the maximum number of processes to run in parallel. In our case, we use this to prevent out-of-memory errors.