### PR TITLE
111 handle overflowed tiffs

### DIFF
--- a/champ/convert.py
+++ b/champ/convert.py
@@ -51,13 +51,16 @@ def main(paths, flipud, fliplr, min_column, max_column):
         image_adjustments.append(lambda x: np.fliplr(x))
 
     for directory, tifs in paths.items():
+        print("tifs", tifs)
         hdf5_filename = directory + ".h5"
         if os.path.exists(hdf5_filename):
             log.warn("HDF5 file already exists, skipping creation: %s" % hdf5_filename)
             continue
+        print("creating h5", hdf5_filename)
         with h5py.File(hdf5_filename, 'a') as h5:
             tiff_stack = load_tiff_stack(list(tifs), image_adjustments, min_column, max_column)
             for t in tiff_stack:
+                print("position", t.micromanager_metadata['PositionName'])
                 for channel, image in t:
                     if channel not in h5:
                         group = h5.create_group(channel)

--- a/champ/convert.py
+++ b/champ/convert.py
@@ -24,12 +24,11 @@ def load_tiff_stack(tifs, adjustments, min_column, max_column):
     # or if each tif contains every image for every field of view in a single concentration
     # then put the files into the appropriate class
     tif = tifffile.TiffFile(tifs[0])
-    if len(tif) > tif.micromanager_metadata['summary']['Positions']:
-        # We have a single file that contains every image for an entire concentration
-        print("** tifs:", tifs)
-        return TifsPerConcentration(tifs, adjustments, min_column, max_column)
-    # Each field of view is in its own tif
-    return TifsPerFieldOfView(tifs, adjustments, min_column, max_column)
+    if len(tifs) == tif.micromanager_metadata['summary']['Positions']:
+        # Each field of view is in its own tif. These may be tif stacks if multiple exposures were taken
+        return TifsPerFieldOfView(tifs, adjustments, min_column, max_column)
+    # We have a single file that contains every image for an entire concentration
+    return TifsPerConcentration(tifs, adjustments, min_column, max_column)
 
 
 def get_all_tif_paths(root_directory):

--- a/champ/convert.py
+++ b/champ/convert.py
@@ -26,6 +26,7 @@ def load_tiff_stack(tifs, adjustments, min_column, max_column):
     tif = tifffile.TiffFile(tifs[0])
     if len(tif) > tif.micromanager_metadata['summary']['Positions']:
         # We have a single file that contains every image for an entire concentration
+        print("** tifs:", tifs)
         return TifsPerConcentration(tifs, adjustments, min_column, max_column)
     # Each field of view is in its own tif
     return TifsPerFieldOfView(tifs, adjustments, min_column, max_column)

--- a/champ/convert.py
+++ b/champ/convert.py
@@ -60,7 +60,7 @@ def main(paths, flipud, fliplr, min_column, max_column):
         with h5py.File(hdf5_filename, 'a') as h5:
             tiff_stack = load_tiff_stack(list(tifs), image_adjustments, min_column, max_column)
             for t in tiff_stack:
-                print("position", t.micromanager_metadata['PositionName'])
+                print("position", t.dataset_name)
                 for channel, image in t:
                     if channel not in h5:
                         group = h5.create_group(channel)

--- a/champ/convert.py
+++ b/champ/convert.py
@@ -66,6 +66,9 @@ def main(paths, flipud, fliplr, min_column, max_column):
                         group = h5.create_group(channel)
                     else:
                         group = h5[channel]
-                    dataset = group.create_dataset(t.dataset_name, image.shape, dtype=image.dtype)
+                    if t.dataset_name not in group:
+                        dataset = group.create_dataset(t.dataset_name, image.shape, dtype=image.dtype)
+                    else:
+                        dataset = group[t.dataset_name]
                     dataset[...] = image
         log.debug("Done with %s" % hdf5_filename)

--- a/champ/convert.py
+++ b/champ/convert.py
@@ -51,16 +51,13 @@ def main(paths, flipud, fliplr, min_column, max_column):
         image_adjustments.append(lambda x: np.fliplr(x))
 
     for directory, tifs in paths.items():
-        print("tifs", tifs)
         hdf5_filename = directory + ".h5"
         if os.path.exists(hdf5_filename):
             log.warn("HDF5 file already exists, skipping creation: %s" % hdf5_filename)
             continue
-        print("creating h5", hdf5_filename)
         with h5py.File(hdf5_filename, 'a') as h5:
             tiff_stack = load_tiff_stack(list(tifs), image_adjustments, min_column, max_column)
             for t in tiff_stack:
-                print("position", t.dataset_name)
                 for channel, image in t:
                     if channel not in h5:
                         group = h5.create_group(channel)

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -130,7 +130,7 @@ class TifsPerConcentration(BaseTifStack):
                         position_text = tif.micromanager_metadata['PositionName']
                         axis_positions = name_regex.search(position_text)
                         if not axis_positions:
-                            print("FAIL: %s" % position_text)
+                            print("Unable to determine the position of this field of view: %s" % position_text)
                         else:
                             first = int(axis_positions.group(1))
                             second = int(axis_positions.group(2))


### PR DESCRIPTION
Resolves #111: We build HDF5 files correctly even when MicroManager mangles our data due to arbitrary filesize limits