### PR TITLE
Fix TIFF parsing bugs, update notebook

### DIFF
--- a/champ/convert.py
+++ b/champ/convert.py
@@ -14,7 +14,12 @@ def load_channel_names(tifs):
     channels = set()
     for filename in tifs:
         tif = tifffile.TiffFile(filename)
-        for channel in tif.micromanager_metadata['summary']['ChNames']:
+        raw_channel_names = tif.micromanager_metadata['summary']['ChNames']
+        if type(raw_channel_names) in (str, unicode):
+            channel_names = [raw_channel_names]
+        else:
+            channel_names = raw_channel_names
+        for channel in channel_names:
             channels.add(sanitize_name(channel))
     return tuple(channels)
 

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -166,6 +166,7 @@ class TifsPerConcentration(BaseTifStack):
                 print("summary['Channels']", summary['Channels'])
                 print("len(channel_names)", len(channel_names))
                 print("len(set(channel_names))", len(set(channel_names)))
+                summary['Channels'] = int(summary['Channels'])
                 assert summary['Channels'] == len(channel_names) == len(set(channel_names)), channel_names
                 # channel_idxs map tif pages to channels
                 channels = [channel_names[i] for i in tif.micromanager_metadata['index_map']['channel']]

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -157,20 +157,13 @@ class TifsPerConcentration(BaseTifStack):
                 # if the images are larger than 512x512, we need to subdivide them
                 subrows, subcolumns = range(height / 512), range(width / 512)
                 # Find channel names and assert unique
-                print("summary['ChNames']", summary['ChNames'])
                 if type(summary['ChNames']) in (str, unicode):
-                    print("yep str")
                     summary['ChNames'] = [sanitize_name(summary['ChNames'])]
-                print("sanitized name", summary['ChNames'])
                 channel_names = [sanitize_name(name) for name in summary['ChNames']]
-                print("summary['Channels']", summary['Channels'])
-                print("len(channel_names)", len(channel_names))
-                print("len(set(channel_names))", len(set(channel_names)))
                 summary['Channels'] = int(summary['Channels'])
                 assert summary['Channels'] == len(channel_names) == len(set(channel_names)), channel_names
                 # channel_idxs map tif pages to channels
                 channels = [channel_names[i] for i in tif.micromanager_metadata['index_map']['channel']]
-                print("channels", channels)
                 for channel, page in zip(channels, tif):
                     all_pages[page.micromanager_metadata['PositionName']].append((channel, page))
 

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -158,7 +158,7 @@ class TifsPerConcentration(BaseTifStack):
                 subrows, subcolumns = range(height / 512), range(width / 512)
                 # Find channel names and assert unique
                 print("summary['ChNames']", summary['ChNames'])
-                if type(summary['ChNames']) == str:
+                if type(summary['ChNames']) in (str, unicode):
                     print("yep str")
                     summary['ChNames'] = [sanitize_name(summary['ChNames'])]
                 print("sanitized name", summary['ChNames'])

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -157,6 +157,7 @@ class TifsPerConcentration(BaseTifStack):
                 # if the images are larger than 512x512, we need to subdivide them
                 subrows, subcolumns = range(height / 512), range(width / 512)
                 # Find channel names and assert unique
+                print("summary['ChNames']", summary['ChNames'])
                 if type(summary['ChNames']) == str:
                     summary['ChNames'] = [summary['ChNames']]
                 channel_names = [sanitize_name(name) for name in summary['ChNames']]

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -163,10 +163,13 @@ class TifsPerConcentration(BaseTifStack):
                     summary['ChNames'] = [sanitize_name(summary['ChNames'])]
                 print("sanitized name", summary['ChNames'])
                 channel_names = [sanitize_name(name) for name in summary['ChNames']]
+                print("summary['Channels']", summary['Channels'])
+                print("len(channel_names)", len(channel_names))
+                print("len(set(channel_names))", len(set(channel_names)))
                 assert summary['Channels'] == len(channel_names) == len(set(channel_names)), channel_names
                 # channel_idxs map tif pages to channels
                 channels = [channel_names[i] for i in tif.micromanager_metadata['index_map']['channel']]
-
+                print("channels", channels)
                 for channel, page in zip(channels, tif):
                     all_pages[page.micromanager_metadata['PositionName']].append((channel, page))
 

--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -159,7 +159,9 @@ class TifsPerConcentration(BaseTifStack):
                 # Find channel names and assert unique
                 print("summary['ChNames']", summary['ChNames'])
                 if type(summary['ChNames']) == str:
-                    summary['ChNames'] = [summary['ChNames']]
+                    print("yep str")
+                    summary['ChNames'] = [sanitize_name(summary['ChNames'])]
+                print("sanitized name", summary['ChNames'])
                 channel_names = [sanitize_name(name) for name in summary['ChNames']]
                 assert summary['Channels'] == len(channel_names) == len(set(channel_names)), channel_names
                 # channel_idxs map tif pages to channels

--- a/notebooks/lda-intensity-estimation.ipynb
+++ b/notebooks/lda-intensity-estimation.ipynb
@@ -22,20 +22,15 @@
     "neg_control_target_name = ''\n",
     "all_channels = ['']\n",
     "data_channel = ''\n",
-    "\n",
     "target_sequence_file = \"/shared/targets.yml\"\n",
-    "nonneg_lda_weights_fpath = '/shared/bLDA_coef_nonneg.txt'\n",
-    "read_name_dir = os.path.join('/shared', project_name, 'read_names')\n",
-    "read_names_by_seq_fpath = os.path.join(read_name_dir, 'read_names_by_seq.txt')\n",
-    "out_fname = 'LDA_intensity_scores.txt'"
+    "nonneg_lda_weights_fpath = '/shared/yeast_beast_LDA_weights.txt'  # for microscope 3\n",
+    "# nonneg_lda_weights_fpath = '/shared/bLDA_coef_nonneg.txt'  # for microscope 2 and 4"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -46,9 +41,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -61,7 +54,11 @@
     "from collections import defaultdict, Counter\n",
     "from IPython.display import HTML, Image\n",
     "from champ import misc, intensity, initialize, seqtools, adapters_cython\n",
-    "import yaml"
+    "import yaml\n",
+    "\n",
+    "read_name_dir = os.path.join('/shared', project_name, 'read_names')\n",
+    "read_names_by_seq_fpath = os.path.join(read_name_dir, 'read_names_by_seq.txt')\n",
+    "out_fname = 'LDA_intensity_scores.txt'"
    ]
   },
   {
@@ -82,9 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with open(target_sequence_file) as f:\n",
@@ -120,9 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "interesting_seqs = set()\n",
@@ -131,7 +124,7 @@
     "for i in range(1, len(target)+1):\n",
     "    stretch.update(seqtools.get_stretch_of_complement_seqs(target, i))\n",
     "insertions = set()\n",
-    "for i in range(1, 4):\n",
+    "for i in range(1, 3):\n",
     "    insertions.update(seqtools.get_contiguous_insertion_seqs(target, i))\n",
     "for i in range(1, 3):\n",
     "    insertions.update(seqtools.get_insertion_seqs(target, i))   \n",
@@ -168,9 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from champ.seqtools import build_interesting_sequences\n",
@@ -183,9 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Decide how many insertions or deletions to allow\n",
@@ -209,9 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "all_read_name_fpath = os.path.join(read_name_dir, 'all_read_names.txt')\n",
@@ -235,9 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "h5_fpaths = glob.glob('*.h5')\n",
@@ -255,9 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "results_dir_name = date\n",
@@ -273,9 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print 'Loading data...'\n",
@@ -286,9 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import time\n",
@@ -300,9 +279,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "int_scores.plot_aligned_images('br', 'o*')"
@@ -311,9 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "int_scores.plot_normalization_constants()"
@@ -322,9 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "int_scores.print_reads_per_channel()"
@@ -333,9 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "good_num_ims_cutoff = len(h5_fpaths) - 3\n",
@@ -356,9 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "good_perfect_read_names = perfect_target_read_names & good_read_names\n",
@@ -369,9 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "int_scores.build_score_given_read_name_given_channel()"
@@ -390,9 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Find only read names with cascade scores\n",
@@ -425,9 +390,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print 'Collating Reads by Sequence'\n",
@@ -443,9 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "interesting_reads[neg_control_target].update(neg_control_target_read_names)"
@@ -480,9 +441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print 'Filtering reads by intensity and seqs by final read count'\n",
@@ -524,9 +483,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(7, 6))\n",
@@ -542,9 +499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print 'Negative Control Seqs:', len(interesting_reads[neg_control_target])"
@@ -560,9 +515,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "concentrations = map(misc.parse_concentration, h5_fpaths)\n",
@@ -573,9 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "trait_name = 'concentration_pM'\n",
@@ -616,9 +567,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
When TIFFs are created by MicroManager in single-TIFF-per-XY-position mode, and you reopen the file later and resave as a single TIFF stack (which was necessary on Microscope 3 since it wasn't saving the TIFFs as OME-TIFF but rather TIFFs with a metadata.txt file, which CHAMP can't use), the channel names are not stored in the same way. That is, instead of a list with a single string, it provides the raw string. Naturally this messed up our code that expects an iterable list and not an iterable string. 

This fixes all related bugs. Additionally, there was an import error in one of the notebooks which is fixed. I also updated the default LDA matrix to be the one appropriate for Microscope 3 (which has  .216666 microns per pixel) since all further work will be done there.