### PR TITLE
Instead of piping all image data into the multiprocessing pool at onc…

### DIFF
--- a/champ/tiff.py
+++ b/champ/tiff.py
@@ -184,7 +184,8 @@ class TifsPerConcentration(BaseTifStack):
                             # Add images
                             for channel, page in channel_pages:
                                 image = page.asarray()
-                                # this subdivision might be incorrect formally, it might be putting them in the wrong part of the larger "box"
+                                # this subdivision might be incorrect formally,
+                                # it might be putting them in the wrong part of the larger "box"
                                 image = image[subrow * 512: (subrow * 512) + 512, subcolumn * 512: (subcolumn * 512) + 512]
                                 for adjustment in self._adjustments:
                                     image = adjustment(image)


### PR DESCRIPTION
…e, we do one concentration at a time. Although this might be slower, since some processes will run out of work and remain idle until the rest are complete and the program can move on to the next concentration, we suspect it will overall be much faster due to the lowered memory bandwidth congestion. Doing a one-off alignment, we could align a single concentration in only 90 minutes, compared to 4 hours or so with the previous method.