### PR TITLE
Add checkpointing

### DIFF
--- a/champ/align.py
+++ b/champ/align.py
@@ -294,8 +294,17 @@ def iterate_all_images(h5_filenames, end_tiles, channel):
             for column in range(min_column, max_column):
                 for row in range(grid._height):
                     image = grid.get(row, column)
-                    if image is not None:
-                        yield row, column, channel, h5_filename, tile_map[image.column], base_name
+                    if image is None:
+                        continue
+                    stats_path = os.path.join(path_info.results_directory, base_name,
+                                              '{}_stats.txt'.format(image.index))
+                    alignment_path = os.path.join(path_info.results_directory, base_name,
+                                                  '{}_all_read_rcs.txt'.format(image.index))
+                    already_aligned = alignment_is_complete(stats_path) and os.path.exists(alignment_path)
+                    if already_aligned:
+                        log.debug("Image already aligned/checkpointed: {}/{}".format(h5_filename, image.index))
+                        continue
+                    yield row, column, channel, h5_filename, tile_map[image.column], base_name
 
 
 def load_read_names(file_path):

--- a/champ/align.py
+++ b/champ/align.py
@@ -35,7 +35,7 @@ def run(cluster_strategy, rotation_adjustment, h5_filenames, path_info, snr, min
     for h5_filename in h5_filenames:
         pool = multiprocessing.Pool(num_processes)
         pool.map_async(alignment_func,
-                       iterate_all_images([h5_filename], end_tiles, alignment_channel), chunksize=chunksize).get(timeout=sys.maxint)
+                       iterate_all_images([h5_filename], end_tiles, alignment_channel, path_info), chunksize=chunksize).get(timeout=sys.maxint)
         pool.close()
         pool.join()
 
@@ -282,7 +282,7 @@ def check_column_for_alignment(cluster_strategy, rotation_adjustment, channel, s
     gc.collect()
 
 
-def iterate_all_images(h5_filenames, end_tiles, channel):
+def iterate_all_images(h5_filenames, end_tiles, channel, path_info):
     # We need an iterator over all images to feed the parallel processes. Since each image is
     # processed independently and in no particular order, we need to return information in addition
     # to the image itself that allow files to be written in the correct place and such


### PR DESCRIPTION
In the event of a crash or manual abort/restart, we need to avoid redundant computation. Currently, we send already-aligned images to the threads and then have them detect that the alignment already happened, but this is still super slow. This commit avoids even assigning already-aligned images to processes.