### PR TITLE
Fix invalid matrix size

### DIFF
--- a/champ/fastqtilercs.py
+++ b/champ/fastqtilercs.py
@@ -44,6 +44,11 @@ class FastqTileRCs(object):
         fq_im_fft = np.fft.fft2(padded_fq_im)
         # Align
         im_data_fft = image_data.fft
+        if im_data_fft.shape != fq_im_fft.shape:
+            raise ValueError("Image and tile matrices are not the same shape! Image:(%dx%d) Tile:(%dx%d)" % (im_data_fft.shape[0],
+                                                                                                             im_data_fft.shape[1],
+                                                                                                             fq_im_fft.shape[0],
+                                                                                                             fq_im_fft.shape[1]))
         cross_corr = abs(np.fft.ifft2(np.conj(fq_im_fft) * im_data_fft))
         max_corr = cross_corr.max()
         max_idx = misc.max_2d_idx(cross_corr)

--- a/champ/imagedata.py
+++ b/champ/imagedata.py
@@ -21,11 +21,11 @@ class ImageData(object):
 
     def set_fft(self, padding):
         totalx, totaly = np.array(padding) + np.array(self.image.shape)
-        w = misc.next_power_of_2(totalx)
-        h = misc.next_power_of_2(totaly)
+        dimension = int(max(misc.next_power_of_2(totalx),
+                        misc.next_power_of_2(totaly)))
         padded_im = np.pad(self.image,
-                           ((int(padding[0]), int(w) - int(totalx)), (int(padding[1]), int(h) - int(totaly))),
+                           ((int(padding[0]), dimension - int(totalx)), (int(padding[1]), dimension - int(totaly))),
                            mode='constant')
-        if padded_im.shape != (h, w):
+        if padded_im.shape != (dimension, dimension):
             raise ValueError("FFT of microscope image is not a power of 2, this will cause the program to stall.")
         self.fft = np.fft.fft2(padded_im)


### PR DESCRIPTION
An image was mysteriously padded to a non-square size, which should not be possible. To resolve this we now use the largest padded dimension for both sides.